### PR TITLE
Fixes left-hand menu css in IE11.

### DIFF
--- a/frontend/styles/components/brand-expression.js
+++ b/frontend/styles/components/brand-expression.js
@@ -20,4 +20,12 @@ style(`
   .brand-expression__title {
     margin-left: var(--lumo-space-s);
   }
+
+  /* IE 11 workarounds */
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    .navi-drawer[rail]:not([open]):not(:hover) .brand-expression__logo {
+      /* With max-width, the logo gets too wide */
+      width: 100%;
+    }
+  }
 `)

--- a/frontend/styles/components/navi-drawer.js
+++ b/frontend/styles/components/navi-drawer.js
@@ -130,4 +130,26 @@ style(`
       width: var(--navi-drawer-rail-width);
     }
   }
+
+  /* IE 11 workarounds */
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    .navi-drawer__scrim,
+    .navi-drawer__content {
+      /* z-index is needed on each level for IE11 support. For other browsers .navi-drawer z-index is enough */
+      z-index: 2
+    }
+
+
+    .brand-expression .h3 {
+      font-size: 1.375rem;
+    }
+  }
+
+  /* Push the drawer out of view */
+  @media all and (max-width: 1023px) and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    .navi-drawer:not([open]) .navi-drawer__content {
+      /* IE11 doesn't understand nested calc's, so flatting one level */
+      margin-left: -18.9rem;
+    }
+  }
 `);


### PR DESCRIPTION
Partly fixes: #28, but focuses only on menu. More work needed on top bar, content and views.

The menu floated on top of the text and a lot of small stuff was bonkers when looking at BAS in IE11. The menu is now good enough for proper use.

### What was fixed
- z-index was not applied to children in dom
- nested calc() did not work
- reference to --lumo-font-size-xl did not work for some reason
- logo resized wrong in small view

### What it looks like with this fix
Chrome in the back, IE11 in the front.

💙 *Normal view with wide window*
![after-wide-view](https://user-images.githubusercontent.com/525503/61893423-b4dc7980-af16-11e9-9792-818785cfb431.png)

💙 *Normal view with collapse button pressed*
![after-collapse-button](https://user-images.githubusercontent.com/525503/61893465-cb82d080-af16-11e9-9641-86d4429c5307.png)

💙 *Slim view*
![after-slim-menu-closed](https://user-images.githubusercontent.com/525503/61893486-d473a200-af16-11e9-9e64-946bda78f4bb.png)

💙 *Slim view with opened menu*
![after-slim-menu-open](https://user-images.githubusercontent.com/525503/61893520-e81f0880-af16-11e9-806a-79cf0e2f66f6.png)

### What it looks like in master, before this fix
Chrome in the back, IE11 in the front.

❌ *Normal view with wide window*
![before-wide-view](https://user-images.githubusercontent.com/525503/61893642-3f24dd80-af17-11e9-8958-3d04cbd8a3a9.png)

❌ *Normal view with collapse button pressed*
![before-collapse-button](https://user-images.githubusercontent.com/525503/61893659-451abe80-af17-11e9-973f-e77ff636aa59.png)

❌ *Slim view*
![before-slim-menu-closed](https://user-images.githubusercontent.com/525503/61893666-4946dc00-af17-11e9-99fe-952591846238.png)

❌ *Slim view with opened menu*
![before-slim-menu-open](https://user-images.githubusercontent.com/525503/61893674-4cda6300-af17-11e9-8b79-06b19ea5b958.png)
