### PR TITLE
Fixes app bar styles in IE11

### DIFF
--- a/frontend/styles/components/app-bar.js
+++ b/frontend/styles/components/app-bar.js
@@ -19,6 +19,8 @@ style(`
   .app-bar__navi-icon,
   .app-bar__context-icon {
     margin-right: var(--lumo-space-l);
+    margin-bottom: calc((var(--app-bar-height-mobile) - var(--lumo-icon-size-m)) / 2);
+    margin-top: calc((var(--app-bar-height-mobile) - var(--lumo-icon-size-m)) / 2);
   }
 
   /* Title */
@@ -30,9 +32,18 @@ style(`
     white-space: nowrap;
   }
 
+  .app-bar__title:not(:empty) {
+    margin-bottom: calc((var(--app-bar-height-mobile) - (var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
+    margin-top: calc((var(--app-bar-height-mobile) - (var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
+  }
+
   /* Action items */
   .app-bar__action-items > *:not(:last-child) {
     margin-right: var(--lumo-space-s);
+  }
+
+  .app-bar__tab-container {
+    padding: 0 var(--lumo-space-m);
   }
 
   /* Search */
@@ -62,40 +73,39 @@ style(`
     flex-shrink: 0;
   }
 
-  @media (max-width: 1023px) {
-    .app-bar__navi-icon,
-    .app-bar__context-icon {
-      margin-bottom: calc(calc(var(--app-bar-height-mobile) - var(--lumo-icon-size-m)) / 2);
-      margin-top: calc(calc(var(--app-bar-height-mobile) - var(--lumo-icon-size-m)) / 2);
-    }
-
-    .app-bar__title:not(:empty) {
-      margin-bottom: calc(calc(var(--app-bar-height-mobile) - calc(var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
-      margin-top: calc(calc(var(--app-bar-height-mobile) - calc(var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
-    }
-
-    .app-bar__tab-container {
-      padding: 0 var(--lumo-space-m);
-    }
-  }
-
   @media (min-width: 1024px) {
     .app-bar__navi-icon {
       display: none;
     }
 
     .app-bar__context-icon {
-      margin-bottom: calc(calc(var(--app-bar-height-desktop) - var(--lumo-icon-size-m)) / 2);
-      margin-top: calc(calc(var(--app-bar-height-desktop) - var(--lumo-icon-size-m)) / 2);
+      margin-bottom: calc((var(--app-bar-height-desktop) - var(--lumo-icon-size-m)) / 2);
+      margin-top: calc((var(--app-bar-height-desktop) - var(--lumo-icon-size-m)) / 2);
     }
 
     .app-bar__title:not(:empty) {
-      margin-bottom: calc(calc(var(--app-bar-height-desktop) - calc(var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
-      margin-top: calc(calc(var(--app-bar-height-desktop) - calc(var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
+      margin-bottom: calc((var(--app-bar-height-desktop) - (var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
+      margin-top: calc((var(--app-bar-height-desktop) - (var(--lumo-font-size-l) * var(--lumo-line-height-xs))) / 2);
     }
 
     .app-bar__tab-container {
       padding: 0 var(--lumo-space-l);
     }
   }
+
+    /* IE 11 workarounds */
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      /* IE 11 can't handle different themes for sub-parts of the application, without the parts having own
+         shadow roots. Instead of polluting the code for all browsers, the relevant colors of dark theme
+         is hard coded here. */
+      .app-bar {
+        color: hsl(214, 100%, 98%);
+        background-color: hsl(214, 35%, 21%);
+        box-shadow: 0 2px 4px -1px hsla(214, 8%, 4%, 0.23), 0 3px 12px -1px hsla(214, 12%, 6%, 0.32);
+      }
+
+      .app-bar__title {
+        color: hsl(214, 100%, 98%);
+      }
+    }
 `)


### PR DESCRIPTION
Partly fixes: #28, but focuses only on the top app bar. Menu is fixed in #57, and more work needed on content area and views.



### What was fixed
- The menu did not have the dark colors as IE11 can't handle theme="" for single divs. You have to add a custom element with an own shadow root to make theme work correctly in IE11. However, that would have unnecessarily polluted the code in all modern browsers, so this uses IE11 specific CSS to hard code the colors for IE11.
- Also nested CSS calc() were used, which IE11 can't handle.

### What it looks like with this fix
IE11 in the back, Chrome in the front.

💙 *Wide view*
![after-wide](https://user-images.githubusercontent.com/525503/62109954-0b9ad800-b2b6-11e9-9c07-fe2516888d73.png)

💙 *Narrow view*
![after-narrow](https://user-images.githubusercontent.com/525503/62109959-0f2e5f00-b2b6-11e9-86c8-488fab7d759c.png)

### What it looks like in master, before this fix
IE11 in the back, Chrome in the front.

❌ *Wide view*
![before-wide](https://user-images.githubusercontent.com/525503/62109934-ff167f80-b2b5-11e9-9a72-030a38487d68.png)

❌ *Narrow*
![before-narrow](https://user-images.githubusercontent.com/525503/62109948-06d62400-b2b6-11e9-9b0f-3a20f43cb2a2.png)

