### PR TITLE
IE11 fix: move background to css file, instead of inline

### DIFF
--- a/frontend/styles/shared-styles.js
+++ b/frontend/styles/shared-styles.js
@@ -103,4 +103,8 @@ styleInclude(
   .app-footer-outer {
     z-index: 3;
   }
+
+  .root {
+    background-color: var(--lumo-contrast-5pct);
+  }
 `);

--- a/src/main/java/com/vaadin/starter/business/ui/MainLayout.java
+++ b/src/main/java/com/vaadin/starter/business/ui/MainLayout.java
@@ -67,7 +67,6 @@ public class MainLayout extends FlexBoxLayout
                 });
 
         addClassName(CLASS_NAME);
-        setBackgroundColor(LumoStyles.Color.Contrast._5);
         setFlexDirection(FlexDirection.COLUMN);
         setSizeFull();
 


### PR DESCRIPTION
Partly fixes: #28, but focuses only on the missing background color in IE11. Menu is fixed in #57, top app bar in #59, and more work needed on specific views.

### What was fixed
- Setting css variables into style="" with Java will not work in IE11, e.g. `style="background-color: var(--lumo-contrast-5pct);"`. It will not appear in the DOM at all. The same code will work if it is attached to a class name, e.g. `.root { background-color: var(--lumo-contrast-5pct); }

### 💙 What it looks like with this fix
![after-bg](https://user-images.githubusercontent.com/525503/62118612-a69bae00-b2c6-11e9-9c35-775e79df86aa.png)

### ❌ What it looks like in master, before this fix
![before-bg](https://user-images.githubusercontent.com/525503/62118622-aac7cb80-b2c6-11e9-8b08-1b3272dcfc8d.png)
