### PR TITLE
fix: including default chart theme in charts

### DIFF
--- a/src/main/java/com/vaadin/starter/business/ui/MainLayout.java
+++ b/src/main/java/com/vaadin/starter/business/ui/MainLayout.java
@@ -31,7 +31,7 @@ import com.vaadin.starter.business.ui.views.personnel.Managers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@CssImport(value = "./styles/components/charts.css", themeFor = "vaadin-chart", include = "vaadin-chart-default-theme")
+@CssImport(value = "./styles/components/charts.css", themeFor = "vaadin-chart")
 @CssImport(value = "./styles/components/floating-action-button.css", themeFor = "vaadin-button")
 @CssImport(value = "./styles/components/grid.css", themeFor = "vaadin-grid")
 @CssImport("./styles/lumo/border-radius.css")


### PR DESCRIPTION
Based on https://github.com/vaadin/docs/issues/1186 default theme has been renamed in v23

fixes #298 